### PR TITLE
deps: Updated hugo-bin to ^0.27.0

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,6 +1,6 @@
 import gulp from "gulp";
 import {spawn} from "child_process";
-import hugoBin from "hugo-bin";
+import hugo from "hugo-bin";
 import gutil from "gulp-util";
 import flatten from "gulp-flatten";
 import postcss from "gulp-postcss";
@@ -76,7 +76,7 @@ function buildSite(cb, options, environment = "development") {
 
   process.env.NODE_ENV = environment;
 
-  return spawn(hugoBin, args, {stdio: "inherit"}).on("close", (code) => {
+  return spawn(hugo, args, {stdio: "inherit"}).on("close", (code) => {
     if (code === 0) {
       browserSync.reload();
       cb();

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-postcss": "^7.0.1",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^5.0.0",
-    "hugo-bin": "^0.23.0",
+    "hugo-bin": "^0.27.0",
     "imports-loader": "^0.8.0",
     "postcss-cssnext": "^3.1.0",
     "postcss-import": "^11.1.0",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/victor-hugo/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Updating dependency `hugo-bin` to `^0.27.0` to allow latest Hugo features to be used. 
Breaking change in `hugo-bin` was adapted in `gulpfile`: `import hugo from "hugo-bin"` rather than `import hugoBin...`

**- Test plan**

    yarn install
    yarn build
    yarn server

**- Description for the changelog**

Deps `hugo-bin` upgraded to `0.27`, with modification of the variable imported in `gulpfile.babel.js`: `hugo` rather than `hugoBin`