### PR TITLE
server-preview: Ensure hugo-preview is run for subsequent builds, too.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,7 +23,7 @@ gulp.task("hugo-preview", (cb) => buildSite(cb, hugoArgsPreview));
 
 // Run server tasks
 gulp.task("server", ["hugo", "css", "js", "fonts"], (cb) => runServer(cb));
-gulp.task("server-preview", ["hugo-preview", "css", "js", "fonts"], (cb) => runServer(cb));
+gulp.task("server-preview", ["hugo-preview", "css", "js", "fonts"], (cb) => runServer(cb, "hugo-preview"));
 
 // Build/production tasks
 gulp.task("build", ["css", "js", "fonts"], (cb) => buildSite(cb, [], "production"));
@@ -61,7 +61,7 @@ gulp.task('fonts', () => (
 ));
 
 // Development server with browsersync
-function runServer() {
+function runServer(cb, hugoTask = "hugo") {
   browserSync.init({
     server: {
       baseDir: "./dist"
@@ -70,7 +70,7 @@ function runServer() {
   gulp.watch("./src/js/**/*.js", ["js"]);
   gulp.watch("./src/css/**/*.css", ["css"]);
   gulp.watch("./src/fonts/**/*", ["fonts"]);
-  gulp.watch("./site/**/*", ["hugo"]);
+  gulp.watch("./site/**/*", [hugoTask]);
 };
 
 /**


### PR DESCRIPTION
**- Summary**

After an initial hugo-preview build, the runServer function reverts to running the non-preview hugo task.

(I've left the unused callback argument in place in case anyone else makes use of it in their local modifications. Also, the eslint rules as shipped do not complain.)

**- Test plan**

```
$ yarn start-preview
```

Wait for server start running.

```
^Z
$ bg
$ touch site/config.toml
```

Compare gulp output, before and after change.

**- Description for the changelog**

server-preview: Ensure hugo-preview is run for subsequent builds, too.

**- A picture of a cute animal (not mandatory but encouraged)**

I believe our cat is too deadly a creature to be appropriate, despite all its cuteness.