### PR TITLE
Fix `yarn run` with node version 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "whatwg-fetch": "^3.0.0"
   },
   "resolutions": {
-    "natives": "1.1.3"
+    "natives": "1.1.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4726,10 +4726,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@1.1.3, natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
-  integrity sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==
+natives@1.1.6, natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
`yarn run start` fails with node 11.1.0 (and most likely node 11.0.0 as well).

Upgrading `natives` in `package.json`'s `resolutions` block to version 1.1.6 solves this issue.
See: https://github.com/gulpjs/gulp/issues/2246

![img](https://media.giphy.com/media/12BLGCegS5WEaQ/giphy.gif)