### PR TITLE
Remove duplicate closing tag for head

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -12,7 +12,6 @@
     <link href="{{ relURL . }}" rel="stylesheet">
   {{ end }}
 </head>
-</head>
 
 <body>
 


### PR DESCRIPTION
**- Summary**
Fixes a duplicate closing HTML tag.

**- Test plan**

Load the page and inspect the source to ensure the second head tag is gone.

**- Description for the changelog**

- HTML markup cleanup

**- A picture of a cute animal (not mandatory but encouraged)**
