### PR TITLE
CleanWebpackPlugin has changed how it accepts configuration options

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -26,7 +26,12 @@ module.exports = merge(common, {
   },
 
   plugins: [
-    new CleanWebpackPlugin(["dist/**/*.js", "dist/**/*.css", "site/content/webpack.json"]),
+    new CleanWebpackPlugin({
+      cleanOnceBeforeBuildPatterns: [
+        "dist/**/*.js",
+        "dist/**/*.css",
+        "site/content/webpack.json"
+      ]}),
 
     new MiniCssExtractPlugin({
       filename: "[name].css",


### PR DESCRIPTION
fixes #167 

**- Summary**

Recent changes to the upstream clean-webpack-plugin have made the default path list no longer work. This pr changes the config structure to match the pattern


**- Test plan**

`npm run preview` and `npm start` now work previously they would error with 


```

Watching for config changes in $dir/go/src/github.com/kcollasarundell/victor-hugo/site/config.toml
$dir/go/src/github.com/kcollasarundell/victor-hugo/node_modules/clean-webpack-plugin/dist/clean-webpack-plugin.js:17
      throw new Error(`clean-webpack-plugin only accepts an options object. See:
      ^

Error: clean-webpack-plugin only accepts an options object. See:
            https://github.com/johnagan/clean-webpack-plugin#options-and-defaults-optional
    at new CleanWebpackPlugin ($dir/go/src/github.com/kcollasarundell/victor-hugo/node_modules/clean-webpack-plugin/dist/clean-webpack-plugin.js:17:13)
    at Object.<anonymous> ($dir/go/src/github.com/kcollasarundell/victor-hugo/webpack.dev.js:29:5)
    at Module._compile (internal/modules/cjs/loader.js:799:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:810:10)
    at Module.load (internal/modules/cjs/loader.js:666:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:606:12)
    at Function.Module._load (internal/modules/cjs/loader.js:598:3)
    at Module.require (internal/modules/cjs/loader.js:705:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at WEBPACK_OPTIONS ($dir/go/src/github.com/kcollasarundell/victor-hugo/node_modules/webpack-cli/bin/convert-argv.js:115:13)
    at requireConfig ($dir/go/src/github.com/kcollasarundell/victor-hugo/node_modules/webpack-cli/bin/convert-argv.js:117:6)
    at $dir/go/src/github.com/kcollasarundell/victor-hugo/node_modules/webpack-cli/bin/convert-argv.js:124:17
    at Array.forEach (<anonymous>)
    at module.exports ($dir/go/src/github.com/kcollasarundell/victor-hugo/node_modules/webpack-cli/bin/convert-argv.js:122:15)
    at Object.<anonymous> (/$dir/go/src/github.com/kcollasarundell/victor-hugo/node_modules/webpack-dev-server/bin/webpack-dev-server.js:87:55)
    at Module._compile (internal/modules/cjs/loader.js:799:30)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! victor-hugo@1.0.0 start:webpack: `webpack-dev-server --config webpack.dev.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the victor-hugo@1.0.0 start:webpack script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!    $dir/.npm/_logs/2019-03-28T04_18_45_614Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! victor-hugo@1.0.0 preview:webpack: `npm run start:webpack`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the victor-hugo@1.0.0 preview:webpack script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     $dir/.npm/_logs/2019-03-28T04_18_45_637Z-debug.log
Total in 1699 ms
ERROR: "preview:webpack" exited with 1.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! victor-hugo@1.0.0 preview: `run-p preview:**`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the victor-hugo@1.0.0 preview script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     $dir/.npm/_logs/2019-03-28T04_18_45_723Z-debug.log
```
**- Description for the changelog**

Change configuration structure for clean-webpack-plugin

**- A picture of a cute animal (not mandatory but encouraged)**
![90170220_201f5a8d24_z](https://user-images.githubusercontent.com/393998/55130024-794ec000-516d-11e9-8073-985f82402966.jpg)
A quokka copyright -> [Thomas Rutter](https://www.flickr.com/photos/done/90170220)
