### PR TITLE
Removed stats object from webpack devServer to allow default error logging

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -17,7 +17,6 @@ module.exports = merge(common, {
     port: process.env.PORT || 3000,
     contentBase: path.join(process.cwd(), "./dist"),
     watchContentBase: true,
-    stats: "none",
     quiet: false,
     open: true,
     historyApiFallback: {


### PR DESCRIPTION
**- Summary**
Fixes #174 by removing the `stats: "none"` setting from Webpack's devServer object to allow error logging. With the entire setting gone, the stats setting defaults to `normal` and maintains color in the terminal.

**- Test plan**
Generally just trigger an error somewhere in the SCSS or JS pipeline.

I created a `src/main.scss` file containing some syntax errors and imported it into `src/index.js`. This threw a specific, detailed error in the console for me, where in my instance I left off a closing bracket. If `stats: "none"` is added back, then the build silently fails without any error logging.

**- Description for the changelog**
Added info and error logging to Webpack Dev Server.

**- A picture of a cute animal (not mandatory but encouraged)**
![Otter](https://i.pinimg.com/originals/72/2a/47/722a47af95f06e369073bffa0a5abb23.jpg)