### PR TITLE
Move HMR to dev task only

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint src",
     "start": "run-p start:**",
     "start:hugo": "hugo -d ../dist -s site -vw",
-    "start:webpack": "webpack-dev-server --config webpack.dev.js",
+    "start:webpack": "webpack-dev-server --config webpack.dev.js --hot",
     "preview": "run-p preview:**",
     "preview:hugo": "npm run start:hugo -- -D -F",
     "preview:webpack": "npm run start:webpack",
@@ -17,7 +17,7 @@
     "build:preview": "npm run build:webpack && npm run build:hugo:preview",
     "build:hugo": "hugo -d ../dist -s site -v",
     "build:hugo:preview": "npm run build:hugo -- -D -F",
-    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js --hot --inline"
+    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
**- Summary**
Move the `--hot` flag from the `build:webpack` script to the `start:webpack` script and remove the `--inline` option.

It looks like the `--hot` and `--inline` flags, which I think are intended to be webpack-dev-server options, were mistakenly added to the `build:webpack` script and were adding unnecessary code to production JS bundles (see #178). The `--inline` flag can be removed altogether because the [webpack-dev-server default for `inline` is true](https://webpack.js.org/configuration/dev-server/#devserverinline). Closes #178.

**- Test plan**
Check browser console for webpack-dev-server messages displaying whether HMR is enabled or not.

Before this commit:
<img width="499" alt="Browser console showing only 'Live Reloading enabled'." src="https://user-images.githubusercontent.com/171986/58821686-75ff0700-85ea-11e9-8059-a68cc64a246d.png">

After this commit:
<img width="495" alt="Browser console showing 'Hot Module Replacement enabled'." src="https://user-images.githubusercontent.com/171986/58821784-ab0b5980-85ea-11e9-8326-6cb3d19065c2.png">

**- Description for the changelog**
Enabled webpack hot module replacement (HMR) and fixed HMR code being added unnecessarily to production bundles.