### PR TITLE
Fix TypeError in CleanWebpackPlugin instantiation

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,6 @@
 const merge = require("webpack-merge");
 const path = require("path");
-const CleanWebpackPlugin = require("clean-webpack-plugin");
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const common = require("./webpack.common");


### PR DESCRIPTION
Fix "TypeError: CleanWebpackPlugin is not a constructor" for clean-webpack-plugin >= 3.0.0

When using `npm run preview` with the latest version, an error is thrown as the CleanWebpackPlugin has changed in v. 3.0.0.

This change fixes the import.