### PR TITLE
Remove extraneous `"` from .eslintrc.yml

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,7 @@ env:
 parser: babel-eslint
 
 parserOptions:
-  ecmaVersion": 6
+  ecmaVersion: 6
 
 plugins: [ "import" ]
 


### PR DESCRIPTION
ESLint seems to be reading the `parserOptions` config correctly (ES6 is currently linted correctly), but the extra `"` on `ecmaVersion` should be removed for clarity. Closes #176

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/victor-hugo/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Remove extraneous quotation mark from .eslintrc.yml

**- Test plan**
Make sure ESLint continues to work properly with ES6 syntax. (It does.)

**- Description for the changelog**
Remove extraneous quotation mark from .eslintrc.yml