### PR TITLE
Docs: Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [package.json](package.json#L8) for all tasks.
 |  |  |--index.html    // The index page
 |  |--static           // Files in here ends up in the public folder
 |--src                 // Files that will pass through the asset pipeline
-|  |--css              // Webpack will bundle imported css seperately
+|  |--css              // Webpack will bundle imported css separately
 |  |--index.js         // index.js is the webpack entry for your css & js assets
 ```
 


### PR DESCRIPTION
Noticed this while looking through the README for my netlify CMS site.

![image](https://user-images.githubusercontent.com/5133558/71563316-7c0f7600-2a5b-11ea-9659-2057eb9c49e9.png)

