### PR TITLE
Add netlifly URL aware build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "rimraf dist",
     "build": "npm run build:webpack && npm run build:hugo",
     "build:preview": "npm run build:webpack && npm run build:hugo:preview",
-    "build:hugo": "hugo -d ../dist -s site -v -b ${URL:-'/'}",
+    "build:hugo": "hugo -d ../dist -s site -v -b ${DEPLOY_PRIME_URL:-'/'}",
     "build:hugo:preview": "npm run build:hugo -- -D -F",
     "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "rimraf dist",
     "build": "npm run build:webpack && npm run build:hugo",
     "build:preview": "npm run build:webpack && npm run build:hugo:preview",
-    "build:hugo": "hugo -d ../dist -s site -v",
+    "build:hugo": "hugo -d ../dist -s site -v -b ${URL:-'/'}",
     "build:hugo:preview": "npm run build:hugo -- -D -F",
     "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js"
   },


### PR DESCRIPTION
**- Summary**

There is a problem-ish with Hugo itself, as specified here: https://discourse.gohugo.io/t/invalid-sitemap-url/26269/3

If you have 
```
baseurl = "/"
```
Hugo will generate a sitemap that does not have valid URLs, according to the sitemap standard. This is problematic if you want to add your site to Google search index.

If you do 
```
baseurl = "your.base.url.com"
```
Then all your dev environment links will link to your production site, which is not great.

Other templates added their own magic to the mix, as is the example of Atlas template: https://github.com/indigotree/atlas/pull/39/files#diff-7291edac743a0e6f594d817cb46f00cb3866bf89f40569ae494e36c1b722afa8R65

In this approach I leveraged the Netlify build env:

Netlifly has a build env `DEPLOY_PRIME_URL` that contains the main url of the site. By passing that env variable in the build process (defaulting to `/`) we are able to generate valid site maps with the default templates. 

Warranted that the default value might generate some confusion if they change `baseUrl` and the setting is overridden by the build process. Suggestions are welcome. Maybe making an if/elif would be better.

**- Test plan**

`npm run build` Generates:
```
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
  xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>/about/</loc>
    <lastmod>2021-08-01T00:00:01+00:00</lastmod>
  </url><url>
    <loc>/blog/</loc>
    <lastmod>2021-08-01T00:00:01+00:00</lastmod>
  </url><url>
```

`DEPLOY_PRIME_URL="some_url.com" npm run build`
Generates
```
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
  xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>some_url.com/about/</loc>
    <lastmod>2021-08-01T00:00:01+00:00</lastmod>
  </url><url>
    <loc>some_url.com/blog/</loc>
    <lastmod>2021-08-01T00:00:01+00:00</lastmod>
  </url><url>
```
**- Description for the changelog**
- Fix default sitemaps to contain base url of production site during build

**- A picture of a cute animal (not mandatory but encouraged)**
